### PR TITLE
fix break sound setting won't be saved

### DIFF
--- a/MainWindowCore.cs
+++ b/MainWindowCore.cs
@@ -407,7 +407,7 @@ namespace MajdataEdit
             Bass.BASS_ChannelGetAttribute(bgmStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.BGM_Level);
             Bass.BASS_ChannelGetAttribute(answerStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Answer_Level);
             Bass.BASS_ChannelGetAttribute(judgeStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Judge_Level);
-            Bass.BASS_ChannelGetAttribute(breakStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Break_Level);
+            Bass.BASS_ChannelGetAttribute(judgeBreakStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Break_Level);
             Bass.BASS_ChannelGetAttribute(judgeExStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Ex_Level);
             Bass.BASS_ChannelGetAttribute(touchStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Touch_Level);
             Bass.BASS_ChannelGetAttribute(slideStream, BASSAttribute.BASS_ATTRIB_VOL, ref setting.Slide_Level);


### PR DESCRIPTION
如果缺失break.wav文件则无法保存break音量，因为breakStream在缺失文件的情况下不会被创建，但保存时读取的设置是breakStream的音量参数。从逻辑上说，存在不想听欢呼声所以删除break.wav的可能性，但是几乎没有留着break.wav欢呼声但不留judge_break.wav绝赞主音效的可能性。因此将saveSetting()中读取的设置改为judgeBreakStream。