### PR TITLE
Sample Control on Export

### DIFF
--- a/MainWindowCore.cs
+++ b/MainWindowCore.cs
@@ -1216,6 +1216,33 @@ namespace MajdataEdit
             return false;
         }
 
+        string GetViewerWorkingDirectory()
+        {
+            string tempPath = "";
+            Process baseProc;
+            Process[] viewProcs;
+            viewProcs = Process.GetProcessesByName("MajdataView");
+            // Prioritize Majdata First
+            if (viewProcs.Length > 0)
+            {
+                baseProc = viewProcs.First();
+                string pwd;
+                pwd = baseProc.StartInfo.WorkingDirectory.TrimEnd('/');
+                if (pwd.Length == 0) pwd = ".";
+                tempPath = pwd + "/MajdataView_Data/StreamingAssets";
+            }
+            else
+            {
+                viewProcs = Process.GetProcessesByName("Unity");
+            }
+            if (viewProcs.Length <= 0)
+                throw new Exception("Unable to find MajdataView instance!");
+
+            return (tempPath.Length == 0) ?
+                Environment.CurrentDirectory + "/SFX" :
+                tempPath;
+        }
+
         void InternalSwitchWindow(bool moveToPlace = true)
         {
             var windowPtr = FindWindow(null, "MajdataView");

--- a/SoundEffect.cs
+++ b/SoundEffect.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Timers;
 using Un4seen.Bass;
 using Newtonsoft.Json;
@@ -440,7 +441,19 @@ namespace MajdataEdit
         void renderSoundEffect(double delaySeconds)
         {
             //TODO: 改为异步并增加提示窗口
-            var path = Environment.CurrentDirectory + "/SFX/";
+            string path = Environment.CurrentDirectory + "/SFX";
+            string tempPath = GetViewerWorkingDirectory();
+            string converterPath;
+
+            List<string> pathEnv = new List<string>();
+            pathEnv.Add(tempPath);
+            pathEnv.AddRange(Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator));
+            converterPath = pathEnv.Where((scanPath) => {
+                bool isExists = File.Exists(scanPath + "/ffmpeg.exe");
+                return isExists;
+            }).FirstOrDefault();
+
+            bool throwErrorOnMismatch = converterPath.Length == 0;
 
             //默认参数：16bit
             int bgmSample = Bass.BASS_SampleLoad(maidataDir + "/track.mp3", 0, 0, 1, BASSFlag.BASS_DEFAULT);


### PR DESCRIPTION
Known Issue with current sample system:
- Mono audios will have its sample speed up by 100%.<br>*If there's a way to check it sure, need to check (and reload) the 2-channel one.*

I'll adjust everything later, unless this implementation is better than current one to override it.