### PR TITLE
Syntax Checker

### DIFF
--- a/Langs/Langs.en-US.resx
+++ b/Langs/Langs.en-US.resx
@@ -475,4 +475,7 @@ Click OK to start render.</value>
   <data name="SyntaxDisplay" xml:space="preserve">
     <value>Syntax Check</value>
   </data>
+  <data name="InternalErr" xml:space="preserve">
+    <value>Internal Error</value>
+  </data>
 </root>

--- a/Langs/Langs.en-US.resx
+++ b/Langs/Langs.en-US.resx
@@ -478,4 +478,7 @@ Click OK to start render.</value>
   <data name="InternalErr" xml:space="preserve">
     <value>Internal Error</value>
   </data>
+  <data name="SyntaxWarning" xml:space="preserve">
+    <value>[Warning] The chart should end with "E" : "{0}"({1}L,{2}C)</value>
+  </data>
 </root>

--- a/Langs/Langs.en-US.resx
+++ b/Langs/Langs.en-US.resx
@@ -463,4 +463,16 @@ Click OK to start render.</value>
   <data name="SmoothSlideAnimeTooltip" xml:space="preserve">
     <value>When enabled, the Slide Track will disappear with the star instead of one judgment area after another.</value>
   </data>
+  <data name="SyntaxCheckLevel1" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="SyntaxCheckLevel2" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="SyntaxCheckLevel3" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="SyntaxDisplay" xml:space="preserve">
+    <value>Syntax Check</value>
+  </data>
 </root>

--- a/Langs/Langs.ja.resx
+++ b/Langs/Langs.ja.resx
@@ -493,4 +493,16 @@ Open Browser to download latest update of Majdata?</value>
     <value>When enabled, the Slide Track will disappear with the star instead of one judgment area after another.</value>
     <comment>Translation required</comment>
   </data>
+  <data name="SyntaxCheckLevel1" xml:space="preserve">
+    <value>無効にする</value>
+  </data>
+  <data name="SyntaxCheckLevel2" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="SyntaxCheckLevel3" xml:space="preserve">
+    <value>有効にする</value>
+  </data>
+  <data name="SyntaxDisplay" xml:space="preserve">
+    <value>構文チェック</value>
+  </data>
 </root>

--- a/Langs/Langs.ja.resx
+++ b/Langs/Langs.ja.resx
@@ -505,4 +505,7 @@ Open Browser to download latest update of Majdata?</value>
   <data name="SyntaxDisplay" xml:space="preserve">
     <value>構文チェック</value>
   </data>
+  <data name="InternalErr" xml:space="preserve">
+    <value>内部エラー</value>
+  </data>
 </root>

--- a/Langs/Langs.ja.resx
+++ b/Langs/Langs.ja.resx
@@ -508,4 +508,7 @@ Open Browser to download latest update of Majdata?</value>
   <data name="InternalErr" xml:space="preserve">
     <value>内部エラー</value>
   </data>
+  <data name="SyntaxWarning" xml:space="preserve">
+    <value>[警告] チャートは「E」で終わる必要があります : "{0}"({1}L,{2}C)</value>
+  </data>
 </root>

--- a/Langs/Langs.zh-CN.resx
+++ b/Langs/Langs.zh-CN.resx
@@ -470,4 +470,7 @@
   <data name="InternalErr" xml:space="preserve">
     <value>内部错误</value>
   </data>
+  <data name="SyntaxWarning" xml:space="preserve">
+    <value>[警告] 谱面应当以"E"结尾："{0}"({1}L,{2}C)</value>
+  </data>
 </root>

--- a/Langs/Langs.zh-CN.resx
+++ b/Langs/Langs.zh-CN.resx
@@ -455,4 +455,16 @@
   <data name="SmoothSlideAnimeTooltip" xml:space="preserve">
     <value>启用后，Slide轨迹会随着星星消失，而不是以判定区为单位消失</value>
   </data>
+  <data name="SyntaxCheckLevel1" xml:space="preserve">
+    <value>禁用</value>
+  </data>
+  <data name="SyntaxCheckLevel2" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="SyntaxCheckLevel3" xml:space="preserve">
+    <value>开启</value>
+  </data>
+  <data name="SyntaxDisplay" xml:space="preserve">
+    <value>语法检查</value>
+  </data>
 </root>

--- a/Langs/Langs.zh-CN.resx
+++ b/Langs/Langs.zh-CN.resx
@@ -467,4 +467,7 @@
   <data name="SyntaxDisplay" xml:space="preserve">
     <value>语法检查</value>
   </data>
+  <data name="InternalErr" xml:space="preserve">
+    <value>内部错误</value>
+  </data>
 </root>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -33,12 +33,21 @@
         <Label x:Name="ErrCount" Grid.Column="1" Content="0" 
             Foreground="White" 
             HorizontalAlignment="Left" HorizontalContentAlignment="Center"
-            Margin="6,236,0,0" Grid.RowSpan="2" VerticalAlignment="Top" Width="86" PreviewMouseDoubleClick="SyntaxCheckButton_Click"/>
+            Margin="44,201,0,0" Grid.RowSpan="2" VerticalAlignment="Top" Width="53" Height="25" PreviewMouseDoubleClick="SyntaxCheckButton_Click"/>
 
-        <Label x:Name="ErrCount_Label" Grid.Column="1" Content="Error(s)" 
+        <Label x:Name="ErrCount_Label" Content="Error" 
                Foreground="White" 
-               HorizontalAlignment="Left" HorizontalContentAlignment="Center"
-               Margin="6,211,0,0" Grid.RowSpan="2" VerticalAlignment="Top" Width="86" PreviewMouseDoubleClick="SyntaxCheckButton_Click"/>
+               HorizontalAlignment="Left" HorizontalContentAlignment="Left"
+               Margin="2,201,0,0" Grid.RowSpan="2" VerticalAlignment="Top" Width="45" PreviewMouseDoubleClick="SyntaxCheckButton_Click" Grid.Column="1" RenderTransformOrigin="0.5,0.5">
+            <Label.RenderTransform>
+                <TransformGroup>
+                    <ScaleTransform/>
+                    <SkewTransform/>
+                    <RotateTransform Angle="0.647"/>
+                    <TranslateTransform/>
+                </TransformGroup>
+            </Label.RenderTransform>
+        </Label>
 
         <Image x:Name="MusicWave" Height="74" VerticalAlignment="Bottom" MouseWheel="MusicWave_MouseWheel"
                PreviewMouseLeftButtonDown="MusicWave_PreviewMouseLeftButtonDown" MouseMove="MusicWave_MouseMove"

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -9,10 +9,15 @@
     lex:ResxLocalizationProvider.DefaultDictionary="Langs"
     x:Name="TheWindow" x:Class="MajdataEdit.MainWindow"
     mc:Ignorable="d"
-    Title="MajdataEdit" Height="502" Width="720.5" Loaded="Window_Loaded" Closing="Window_Closing" MinHeight="517"
+    Title="MajdataEdit" Height="589" Width="720.5" Loaded="Window_Loaded" Closing="Window_Closing" MinHeight="517"
     WindowStartupLocation="CenterScreen">
 
     <Grid Margin="0" DragEnter="Grid_DragEnter" AllowDrop="True" Drop="Grid_Drop">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="0*"/>
+            <RowDefinition Height="501*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
         <Grid.Background>
             <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
                 <GradientStop Color="#FF526675" />
@@ -20,18 +25,29 @@
             </LinearGradientBrush>
         </Grid.Background>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition />
+            <ColumnDefinition Width="3*" />
+            <ColumnDefinition Width="358*"/>
+            <ColumnDefinition Width="360*" />
         </Grid.ColumnDefinitions>
+
+        <Label x:Name="ErrCount" Grid.Column="1" Content="0" 
+            Foreground="White" 
+            HorizontalAlignment="Left" HorizontalContentAlignment="Center"
+            Margin="6,236,0,0" Grid.RowSpan="2" VerticalAlignment="Top" Width="86" PreviewMouseDoubleClick="SyntaxCheckButton_Click"/>
+
+        <Label x:Name="ErrCount_Label" Grid.Column="1" Content="Error(s)" 
+               Foreground="White" 
+               HorizontalAlignment="Left" HorizontalContentAlignment="Center"
+               Margin="6,211,0,0" Grid.RowSpan="2" VerticalAlignment="Top" Width="86" PreviewMouseDoubleClick="SyntaxCheckButton_Click"/>
 
         <Image x:Name="MusicWave" Height="74" VerticalAlignment="Bottom" MouseWheel="MusicWave_MouseWheel"
                PreviewMouseLeftButtonDown="MusicWave_PreviewMouseLeftButtonDown" MouseMove="MusicWave_MouseMove"
-               Grid.ColumnSpan="2" SizeChanged="MusicWave_SizeChanged" />
-        <Line StrokeThickness="3" Y2="56" Height="74" VerticalAlignment="Bottom" Stroke="Red" Y1="15" Grid.Column="1"
-              HorizontalAlignment="Left" Width="45" />
+               Grid.ColumnSpan="3" SizeChanged="MusicWave_SizeChanged" Grid.RowSpan="2" Grid.Row="1" />
+        <Line StrokeThickness="3" Y2="56" Height="74" VerticalAlignment="Bottom" Stroke="Red" Y1="15"
+              HorizontalAlignment="Left" Width="45" Grid.ColumnSpan="2" Margin="357,0,0,0" Grid.RowSpan="2" Grid.Row="1" Grid.Column="1" />
 
         <Menu Height="19" VerticalAlignment="Top" Background="{DynamicResource ButtonsBackground}"
-              Foreground="{DynamicResource ButtonForeground}" Grid.ColumnSpan="2">
+              Foreground="{DynamicResource ButtonForeground}" Grid.ColumnSpan="3" Grid.RowSpan="2">
             <MenuItem Header="{lex:Loc Files}" Foreground="{DynamicResource ButtonForeground}"
                       Template="{DynamicResource DarkMenuItem}">
                 <MenuItem x:Name="Menu_New" Header="{lex:Loc New}" Click="Menu_New_Click" />
@@ -72,6 +88,8 @@
                 <MenuItem Header="{lex:Loc BPMtap}" Click="BPMtap_MenuItem_Click" />
                 <MenuItem x:Name="MenuMuriCheck" Header="{lex:Loc MapMuriDetc}" Click="MuriCheck_Click_1"
                           IsEnabled="False" />
+                <MenuItem x:Name="SyntaxCheckButton" Header="{lex:Loc SyntaxDisplay}" Click="SyntaxCheckButton_Click"
+                          IsEnabled="False" />
             </MenuItem>
             <MenuItem Header="{lex:Loc SimaiWiki}" Click="MenuItem_SimaiWiki_Click"
                       Foreground="{DynamicResource ButtonForeground}" Template="{DynamicResource DarkMenuItem}" />
@@ -80,8 +98,8 @@
             <MenuItem Header="{lex:Loc CheckUpdate}" Click="CheckUpdate_Click"
                       Foreground="{DynamicResource ButtonForeground}" Template="{DynamicResource DarkMenuItem}" />
         </Menu>
-        <Image x:Name="FFTImage" HorizontalAlignment="Right" Margin="0,0,14,92" Width="255" Height="255"
-               VerticalAlignment="Bottom" RenderTransformOrigin="0.5,0.5" Grid.Column="1">
+        <Image x:Name="FFTImage" HorizontalAlignment="Right" Margin="0,0,14,91" Width="254" Height="255"
+               VerticalAlignment="Bottom" RenderTransformOrigin="0.5,0.5" Grid.Column="2" Grid.Row="1">
             <Image.RenderTransform>
                 <TransformGroup>
                     <ScaleTransform />
@@ -92,19 +110,19 @@
             </Image.RenderTransform>
         </Image>
         <CheckBox x:Name="FollowPlayCheck" Content="{lex:Loc TextFollow}" HorizontalAlignment="Left" Height="21"
-                  Margin="9,0,0,129" VerticalAlignment="Bottom" Width="87"
+                  Margin="6,0,0,128" VerticalAlignment="Bottom" Width="87"
                   Foreground="{DynamicResource ButtonForeground}" HorizontalContentAlignment="Right"
                   Click="FollowPlayCheck_Click" Background="{DynamicResource ButtonsBackground}"
-                  Template="{DynamicResource DarkCheck}" />
+                  Template="{DynamicResource DarkCheck}" Grid.Row="1" Grid.Column="1" />
         <RichTextBox x:Name="FumenContent"
                      Padding="0,5" FontFamily="Consolas"
                      Foreground="#FFE8E8E8" TextChanged="FumenContent_TextChanged"
-                     Margin="105,30,10,91" HorizontalScrollBarVisibility="Auto"
+                     Margin="102,29,10,90" HorizontalScrollBarVisibility="Auto"
                      VerticalScrollBarVisibility="Visible"
                      SelectionChanged="FumenContent_SelectionChanged" Grid.ColumnSpan="2"
                      InputMethod.IsInputMethodEnabled="False"
                      AutoWordSelection="False"
-                     PreviewKeyDown="FumenContent_OnPreviewKeyDown">
+                     PreviewKeyDown="FumenContent_OnPreviewKeyDown" Grid.Row="1" Grid.Column="1">
             <RichTextBox.Resources>
                 <RoutedUICommand x:Key="PlayAndPause" Text="PlayAndPause" />
                 <RoutedUICommand x:Key="SaveFile" Text="SaveFile" />
@@ -142,13 +160,13 @@
             </RichTextBox.CommandBindings>
             <FlowDocument />
         </RichTextBox>
-        <Label x:Name="TimeLabel" Content="0:00" HorizontalAlignment="Left" Height="64" Margin="0,17,0,0"
+        <Label x:Name="TimeLabel" Content="0:00" HorizontalAlignment="Left" Height="64" Margin="0,16,0,0"
                VerticalAlignment="Top" Width="105" Foreground="White" FontFamily="Bahnschrift Light" FontSize="50"
-               VerticalContentAlignment="Center" HorizontalContentAlignment="Center" />
-        <ComboBox x:Name="LevelSelector" Margin="10,117,0,0" SelectionChanged="ComboBox_SelectionChanged"
+               VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Grid.Row="1" Grid.ColumnSpan="2" />
+        <ComboBox x:Name="LevelSelector" Margin="7,116,0,0" SelectionChanged="ComboBox_SelectionChanged"
                   HorizontalAlignment="Left" Width="87" Height="21" VerticalAlignment="Top"
                   Background="{DynamicResource ButtonsBackground}" Foreground="{DynamicResource ButtonForeground}"
-                  Template="{DynamicResource DarkComboBox}">
+                  Template="{DynamicResource DarkComboBox}" Grid.Row="1" Grid.Column="1">
 
             <ComboBoxItem Content="EASY" />
             <ComboBoxItem Content="BASIC" />
@@ -158,65 +176,65 @@
             <ComboBoxItem Content="Re:MASTER" />
             <ComboBoxItem Content="ORIGINAL" />
         </ComboBox>
-        <Button x:Name="WaveViewZoomIn" Content="+" HorizontalAlignment="Left" Height="24" Margin="10,0,0,41"
+        <Button x:Name="WaveViewZoomIn" Content="+" HorizontalAlignment="Left" Height="24" Margin="7,0,0,40"
                 VerticalAlignment="Bottom" Width="24" Click="WaveViewZoomIn_Click"
                 Background="{DynamicResource ButtonsBackground}" Foreground="{DynamicResource ButtonForeground}"
-                Template="{DynamicResource DarkButton}" />
-        <Button x:Name="WaveViewZoomOut" Content="-" HorizontalAlignment="Left" Height="24" Margin="10,0,0,10"
+                Template="{DynamicResource DarkButton}" Grid.Row="1" Grid.Column="1" />
+        <Button x:Name="WaveViewZoomOut" Content="-" HorizontalAlignment="Left" Height="24" Margin="7,0,0,9"
                 VerticalAlignment="Bottom" Width="24" Click="WaveViewZoomOut_Click"
                 Background="{DynamicResource ButtonsBackground}" Foreground="{DynamicResource ButtonForeground}"
-                Template="{DynamicResource DarkButton}" />
-        <Label Content="{lex:Loc Difficulty}" HorizontalAlignment="Left" Height="25" Margin="5,143,0,0"
-               VerticalAlignment="Top" Width="45" Foreground="White" />
-        <TextBox x:Name="LevelTextBox" HorizontalAlignment="Left" Height="25" Margin="50,143,0,0" TextWrapping="Wrap"
+                Template="{DynamicResource DarkButton}" Grid.Row="1" Grid.Column="1" />
+        <Label Content="{lex:Loc Difficulty}" HorizontalAlignment="Left" Height="25" Margin="2,142,0,0"
+               VerticalAlignment="Top" Width="45" Foreground="White" Grid.Row="1" Grid.Column="1" />
+        <TextBox x:Name="LevelTextBox" HorizontalAlignment="Left" Height="25" Margin="47,142,0,0" TextWrapping="Wrap"
                  VerticalAlignment="Top" Width="46" VerticalContentAlignment="Center"
                  TextChanged="LevelTextBox_TextChanged" Background="{DynamicResource ButtonsBackground}"
-                 Foreground="{DynamicResource ButtonForeground}" HorizontalContentAlignment="Center" />
-        <Label Content="{lex:Loc Offset}" HorizontalAlignment="Left" Height="25" Margin="5,173,0,0"
-               VerticalAlignment="Top" Width="45" Foreground="White" />
-        <TextBox x:Name="OffsetTextBox" HorizontalAlignment="Left" Height="25" Margin="50,173,0,0" TextWrapping="Wrap"
+                 Foreground="{DynamicResource ButtonForeground}" HorizontalContentAlignment="Center" Grid.Row="1" Grid.Column="1" />
+        <Label Content="{lex:Loc Offset}" HorizontalAlignment="Left" Height="25" Margin="2,172,0,0"
+               VerticalAlignment="Top" Width="45" Foreground="White" Grid.Row="1" Grid.Column="1" />
+        <TextBox x:Name="OffsetTextBox" HorizontalAlignment="Left" Height="25" Margin="47,172,0,0" TextWrapping="Wrap"
                  VerticalAlignment="Top" Width="46" VerticalContentAlignment="Center"
                  Background="{DynamicResource ButtonsBackground}" Foreground="{DynamicResource ButtonForeground}"
                  HorizontalContentAlignment="Center" TextChanged="OffsetTextBox_TextChanged"
-                 MouseWheel="OffsetTextBox_MouseWheel" />
-        <Button x:Name="PlayAndPauseButton" Content="▶" HorizontalAlignment="Left" Margin="58,0,0,91" Width="38"
+                 MouseWheel="OffsetTextBox_MouseWheel" Grid.Row="1" Grid.Column="1" />
+        <Button x:Name="PlayAndPauseButton" Content="▶" HorizontalAlignment="Left" Margin="55,0,0,90" Width="38"
                 Click="PlayAndPauseButton_Click" Height="38" VerticalAlignment="Bottom"
                 Background="{DynamicResource ButtonsBackground}" Foreground="{DynamicResource ButtonForeground}"
-                Template="{DynamicResource DarkButton}" />
-        <Button x:Name="StopButton" Content="◼" HorizontalAlignment="Left" Height="38" Margin="9,0,0,91"
+                Template="{DynamicResource DarkButton}" Grid.Row="1" Grid.Column="1" />
+        <Button x:Name="StopButton" Content="◼" HorizontalAlignment="Left" Height="38" Margin="6,0,0,90"
                 VerticalAlignment="Bottom" Width="38" Click="StopButton_Click"
                 Background="{DynamicResource ButtonsBackground}" Foreground="{DynamicResource ButtonForeground}"
-                Template="{DynamicResource DarkButton}" />
-        <Label x:Name="NoteNowText" Content="行" HorizontalAlignment="Left" Margin="0,74,0,0" VerticalAlignment="Top"
-               Foreground="White" Width="105" HorizontalContentAlignment="Center" Height="25" />
-        <Button x:Name="Op_Button" Content="{lex:Loc RecMode}" Height="30" Margin="9,0,0,166"
+                Template="{DynamicResource DarkButton}" Grid.Row="1" Grid.Column="1" />
+        <Label x:Name="NoteNowText" Content="行" HorizontalAlignment="Left" Margin="0,73,0,0" VerticalAlignment="Top"
+               Foreground="White" Width="105" HorizontalContentAlignment="Center" Height="25" Grid.Row="1" Grid.ColumnSpan="2" />
+        <Button x:Name="Op_Button" Content="{lex:Loc RecMode}" Height="30" Margin="6,0,0,165"
                 VerticalAlignment="Bottom" RenderTransformOrigin="1.1,0.25" Click="Op_Button_Click"
                 HorizontalAlignment="Left" Width="87" Template="{DynamicResource DarkButton}"
                 Foreground="{DynamicResource ButtonForeground}" Background="{DynamicResource ButtonsBackground}"
-                ToolTip="{lex:Loc RecordModeDiscrp}" />
+                ToolTip="{lex:Loc RecordModeDiscrp}" Grid.Row="1" Grid.Column="1" />
         <Label Content="{lex:Loc TouchSpeed}" MouseUp="SettingLabel_MouseUp" HorizontalAlignment="Left" Height="24"
-               Margin="5,0,0,201" VerticalAlignment="Bottom" Width="80" Foreground="White"
-               RenderTransformOrigin="9.667,-2.284" ToolTip="{lex:Loc SpeedSettingTooltip}" />
+               Margin="2,0,0,200" VerticalAlignment="Bottom" Width="80" Foreground="White"
+               RenderTransformOrigin="9.667,-2.284" ToolTip="{lex:Loc SpeedSettingTooltip}" Grid.Row="1" Grid.Column="1" />
         <Label x:Name="ViewerTouchSpeed" MouseUp="SettingLabel_MouseUp" HorizontalAlignment="Left" Height="24"
-               Margin="65,0,0,201" Content="7.0" VerticalAlignment="Bottom" Width="35"
+               Margin="62,0,0,200" Content="7.0" VerticalAlignment="Bottom" Width="35"
                VerticalContentAlignment="Center" Foreground="{DynamicResource ButtonForeground}"
-               HorizontalContentAlignment="Center" ToolTip="{lex:Loc SpeedSettingTooltip}" />
+               HorizontalContentAlignment="Center" ToolTip="{lex:Loc SpeedSettingTooltip}" Grid.Row="1" Grid.Column="1" />
         <Label Content="{lex:Loc Speed}" MouseUp="SettingLabel_MouseUp" HorizontalAlignment="Left" Height="24"
-               Margin="5,0,0,227" VerticalAlignment="Bottom" Width="60" Foreground="White"
-               RenderTransformOrigin="9.667,-2.284" ToolTip="{lex:Loc SpeedSettingTooltip}" />
+               Margin="2,0,0,226" VerticalAlignment="Bottom" Width="60" Foreground="White"
+               RenderTransformOrigin="9.667,-2.284" ToolTip="{lex:Loc SpeedSettingTooltip}" Grid.Row="1" Grid.Column="1" />
         <Label x:Name="ViewerSpeed" MouseUp="SettingLabel_MouseUp" HorizontalAlignment="Left" Height="24"
-               Margin="65,0,0,227" Content="7.0" VerticalAlignment="Bottom" Width="35"
+               Margin="62,0,0,226" Content="7.0" VerticalAlignment="Bottom" Width="35"
                VerticalContentAlignment="Center" Foreground="{DynamicResource ButtonForeground}"
-               HorizontalContentAlignment="Center" ToolTip="{lex:Loc SpeedSettingTooltip}" />
+               HorizontalContentAlignment="Center" ToolTip="{lex:Loc SpeedSettingTooltip}" Grid.Row="1" Grid.Column="1" />
         <Label Content="{lex:Loc Brightness}" MouseUp="SettingLabel_MouseUp" HorizontalAlignment="Left" Height="24"
-               Margin="5,0,0,251" VerticalAlignment="Bottom" Width="60" Foreground="White"
-               RenderTransformOrigin="9.667,-2.284" ToolTip="{lex:Loc SpeedSettingTooltip}" />
-        <Label x:Name="ViewerCover" MouseUp="SettingLabel_MouseUp" Height="24" Margin="65,0,0,251" Content="0.6"
+               Margin="2,0,0,250" VerticalAlignment="Bottom" Width="60" Foreground="White"
+               RenderTransformOrigin="9.667,-2.284" ToolTip="{lex:Loc SpeedSettingTooltip}" Grid.Row="1" Grid.Column="1" />
+        <Label x:Name="ViewerCover" MouseUp="SettingLabel_MouseUp" Height="24" Margin="62,0,0,250" Content="0.6"
                VerticalAlignment="Bottom" VerticalContentAlignment="Center"
                Foreground="{DynamicResource ButtonForeground}" HorizontalAlignment="Left" Width="35"
-               HorizontalContentAlignment="Center" ToolTip="{lex:Loc SpeedSettingTooltip}" />
-        <Grid x:Name="PlbSpdAdjGrid" HorizontalAlignment="Left" Height="105" Margin="105,290,0,0"
-              VerticalAlignment="Top" Width="148" Visibility="Hidden">
+               HorizontalContentAlignment="Center" ToolTip="{lex:Loc SpeedSettingTooltip}" Grid.Row="1" Grid.Column="1" />
+        <Grid x:Name="PlbSpdAdjGrid" HorizontalAlignment="Left" Height="105" Margin="102,289,0,0"
+              VerticalAlignment="Top" Width="148" Visibility="Hidden" Grid.Row="1" Grid.Column="1">
             <Grid.Background>
                 <SolidColorBrush Color="#FF303030" Opacity="0.8" />
             </Grid.Background>
@@ -225,8 +243,8 @@
             <Label x:Name="PlbSpdLabel" Content="100%" Margin="34,46,34,20" Foreground="White" FontWeight="Bold"
                    FontSize="22" HorizontalContentAlignment="Center" />
         </Grid>
-        <Grid x:Name="FindGrid" Margin="0,30,29,0" Grid.Column="1" HorizontalAlignment="Right" Width="272" Height="69"
-              VerticalAlignment="Top" Visibility="Collapsed">
+        <Grid x:Name="FindGrid" Margin="0,29,28,0" Grid.Column="2" HorizontalAlignment="Right" Width="272" Height="69"
+              VerticalAlignment="Top" Visibility="Collapsed" Grid.Row="1">
             <Grid.Background>
                 <SolidColorBrush Color="Black" Opacity="0.2" />
             </Grid.Background>
@@ -243,8 +261,8 @@
             <TextBox x:Name="ReplaceText" HorizontalAlignment="Left" Height="22" Margin="10,37,0,0" TextWrapping="Wrap"
                      VerticalAlignment="Top" Width="231" VerticalContentAlignment="Center" />
         </Grid>
-        <StackPanel x:Name="OverrideModeTipsPopup" Margin="105,30,0,0" HorizontalAlignment="Left"
-                    VerticalAlignment="Top" Orientation="Horizontal" Visibility="Collapsed">
+        <StackPanel x:Name="OverrideModeTipsPopup" Margin="102,29,0,0" HorizontalAlignment="Left"
+                    VerticalAlignment="Top" Orientation="Horizontal" Visibility="Collapsed" Grid.Row="1" Height="0" Width="0" Grid.Column="1">
             <StackPanel.Background>
                 <SolidColorBrush Color="Black" Opacity="0.8" />
             </StackPanel.Background>
@@ -260,7 +278,7 @@
                 <TextBlock TextDecorations="Underline" FontSize="10" Text="{lex:Loc Key=WhatsThis}" />
             </Label>
         </StackPanel>
-        <Rectangle x:Name="Cover" Fill="#FF1F1F1F" Margin="0,19,0,0" Stroke="Black" Grid.ColumnSpan="2"
-                   d:IsHidden="True" />
+        <Rectangle x:Name="Cover" Fill="#FF1F1F1F" Margin="0,18,0,0" Stroke="Black" Grid.ColumnSpan="3"
+                   d:IsHidden="True" Grid.RowSpan="2" Grid.Row="1" />
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -490,6 +490,7 @@ public partial class MainWindow : Window
         SetSavedState(true);
         SimaiProcess.Serialize(GetRawFumenText());
         DrawWave();
+        //SyntaxCheck();
     }
 
     private void LevelTextBox_TextChanged(object sender, TextChangedEventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using DiscordRPC.Logging;
 using MajdataEdit.AutoSaveModule;
 using Microsoft.Win32;
 using Un4seen.Bass;
+using MajdataEdit.SyntaxModule;
 using Timer = System.Timers.Timer;
 
 namespace MajdataEdit;
@@ -296,7 +297,50 @@ public partial class MainWindow : Window
         };
         muriCheck.Show();
     }
-
+    private void SyntaxCheckButton_Click(object sender, RoutedEventArgs e)
+    {
+        var mcrWindow = new MuriCheckResult
+        {
+            Owner = this
+        };
+        var errList = SyntaxChecker.ErrorList;
+        errList.ForEach(e => 
+        {
+            e.positionY--;
+            mcrWindow.errorPosition.Add(e);
+            var eRow = new ListBoxItem
+            {
+                Content = e.eMessage,
+                Name = "rr" + mcrWindow.CheckResult_Listbox.Items.Count
+            };
+            eRow.AddHandler(PreviewMouseDoubleClickEvent,
+                new MouseButtonEventHandler(mcrWindow.ListBoxItem_PreviewMouseDoubleClick));
+            mcrWindow.CheckResult_Listbox.Items.Add(eRow);
+        });
+        mcrWindow.Show();
+    }
+    private void SyntaxCheckButton_Click(object sender, MouseButtonEventArgs e)
+    {
+        var mcrWindow = new MuriCheckResult
+        {
+            Owner = this
+        };
+        var errList = SyntaxChecker.ErrorList;
+        errList.ForEach(e =>
+        {
+            e.positionY--;
+            mcrWindow.errorPosition.Add(e);
+            var eRow = new ListBoxItem
+            {
+                Content = e.eMessage,
+                Name = "rr" + mcrWindow.CheckResult_Listbox.Items.Count
+            };
+            eRow.AddHandler(PreviewMouseDoubleClickEvent,
+                new MouseButtonEventHandler(mcrWindow.ListBoxItem_PreviewMouseDoubleClick));
+            mcrWindow.CheckResult_Listbox.Items.Add(eRow);
+        });
+        mcrWindow.Show();
+    }
     private void MenuItem_EditorSetting_Click(object? sender, RoutedEventArgs e)
     {
         var esp = new EditorSettingPanel
@@ -508,7 +552,6 @@ public partial class MainWindow : Window
         esp.Owner = this;
         esp.ShowDialog();
     }
-
     #endregion
 
     #region RichTextbox events
@@ -617,5 +660,8 @@ public partial class MainWindow : Window
         DrawWave();
     }
 
+
     #endregion
+
+    
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -299,27 +299,9 @@ public partial class MainWindow : Window
     }
     private void SyntaxCheckButton_Click(object sender, RoutedEventArgs e)
     {
-        var mcrWindow = new MuriCheckResult
-        {
-            Owner = this
-        };
-        var errList = SyntaxChecker.ErrorList;
-        errList.ForEach(e => 
-        {
-            e.positionY--;
-            mcrWindow.errorPosition.Add(e);
-            var eRow = new ListBoxItem
-            {
-                Content = e.eMessage,
-                Name = "rr" + mcrWindow.CheckResult_Listbox.Items.Count
-            };
-            eRow.AddHandler(PreviewMouseDoubleClickEvent,
-                new MouseButtonEventHandler(mcrWindow.ListBoxItem_PreviewMouseDoubleClick));
-            mcrWindow.CheckResult_Listbox.Items.Add(eRow);
-        });
-        mcrWindow.Show();
+        ShowErrorWindow();
     }
-    private void SyntaxCheckButton_Click(object sender, MouseButtonEventArgs e)
+    void ShowErrorWindow()
     {
         var mcrWindow = new MuriCheckResult
         {
@@ -340,6 +322,10 @@ public partial class MainWindow : Window
             mcrWindow.CheckResult_Listbox.Items.Add(eRow);
         });
         mcrWindow.Show();
+    }
+    private void SyntaxCheckButton_Click(object sender, MouseButtonEventArgs e)
+    {
+        ShowErrorWindow();
     }
     private void MenuItem_EditorSetting_Click(object? sender, RoutedEventArgs e)
     {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -490,7 +490,7 @@ public partial class MainWindow : Window
         SetSavedState(true);
         SimaiProcess.Serialize(GetRawFumenText());
         DrawWave();
-        //SyntaxCheck();
+        SyntaxCheck();
     }
 
     private void LevelTextBox_TextChanged(object sender, TextChangedEventArgs e)

--- a/MainWindowCore.cs
+++ b/MainWindowCore.cs
@@ -337,7 +337,7 @@ public partial class MainWindow : Window
         }
 #if DEBUG
         await SyntaxChecker.ScanAsync(GetRawFumenText());
-        SetErrCount(SyntaxChecker.ErrorList.Count);
+        SetErrCount(SyntaxChecker.GetErrorCount());
 #else
         try
         {
@@ -1112,7 +1112,7 @@ public partial class MainWindow : Window
         {
             if (lastEditorState != EditorControlMethod.Pause && 
                 editorSetting!.SyntaxCheckLevel == 2 && 
-                SyntaxChecker.ErrorList.Count != 0)
+                SyntaxChecker.GetErrorCount() != 0)
             {
                 ShowErrorWindow();
                 return;
@@ -1124,7 +1124,7 @@ public partial class MainWindow : Window
 
     private void TogglePlayAndStop(PlayMethod playMethod = PlayMethod.Normal)
     {
-        if (editorSetting!.SyntaxCheckLevel == 2 && SyntaxChecker.ErrorList.Count != 0)
+        if (editorSetting!.SyntaxCheckLevel == 2 && SyntaxChecker.GetErrorCount() != 0)
         {
             ShowErrorWindow();
             return;

--- a/MainWindowCore.cs
+++ b/MainWindowCore.cs
@@ -11,8 +11,10 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Media.Media3D;
 using System.Windows.Threading;
 using DiscordRPC;
 using MajdataEdit.AutoSaveModule;
@@ -848,8 +850,12 @@ public partial class MainWindow : Window
                             pen.Color = Color.LightPink;
 
                         var xRight = x + (float)(noteD.holdTime / step) * linewidth;
+
+                        //1h[0:1]
+                        if (!float.IsNormal(xRight)) xRight = ushort.MaxValue;
                         if (xRight - x < 1f) xRight = x + 5;
                         graphics.DrawLine(pen, x, y, xRight, y);
+
                     }
 
                     if (noteD.noteType == SimaiNoteType.TouchHold)
@@ -857,6 +863,7 @@ public partial class MainWindow : Window
                         pen.Width = 3;
                         var xDelta = (float)(noteD.holdTime / step) * linewidth / 4f;
                         //Console.WriteLine("HoldPixel"+ xDelta);
+                        if (!float.IsNormal(xDelta)) xDelta = ushort.MaxValue;
                         if (xDelta < 1f) xDelta = 1;
 
                         pen.Color = Color.FromArgb(200, 255, 75, 0);
@@ -894,6 +901,10 @@ public partial class MainWindow : Window
                         pen.DashStyle = DashStyle.Dot;
                         var xSlide = (float)(noteD.slideStartTime / step - startindex) * linewidth;
                         var xSlideRight = (float)(noteD.slideTime / step) * linewidth + xSlide;
+
+                        if (!float.IsNormal(xSlideRight)) xSlideRight = ushort.MaxValue;
+                        if (!float.IsNormal(xSlide)) xSlide = ushort.MaxValue;
+
                         graphics.DrawLine(pen, xSlide, y, xSlideRight, y);
                         pen.DashStyle = DashStyle.Solid;
                     }

--- a/MainWindowCore.cs
+++ b/MainWindowCore.cs
@@ -13,6 +13,7 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using DiscordRPC;
 using MajdataEdit.AutoSaveModule;
 using Microsoft.Win32;
@@ -320,10 +321,18 @@ public partial class MainWindow : Window
         VolumnSetting.IsEnabled = true;
         MenuMuriCheck.IsEnabled = true;
         Menu_ExportRender.IsEnabled = true;
+        SyntaxCheckButton.IsEnabled = true;
         AutoSaveManager.Of().SetAutoSaveEnable(true);
         SetSavedState(true);
+        SyntaxCheck();
     }
 
+    async void SyntaxCheck()
+    {
+        await SyntaxModule.SyntaxChecker.ScanAsync(GetRawFumenText());
+        SetErrCount(SyntaxModule.SyntaxChecker.ErrorList.Count);
+    }
+    void SetErrCount(int eCount) => Dispatcher.Invoke(() => ErrCount.Content = $"{eCount}");
     private void ReadWaveFromFile()
     {
         var useOgg = File.Exists(maidataDir + "/track.ogg");
@@ -567,6 +576,7 @@ public partial class MainWindow : Window
     private void ChartChangeTimer_Elapsed(object? sender, ElapsedEventArgs e)
     {
         Console.WriteLine("TextChanged");
+        SyntaxCheck();
         Dispatcher.Invoke(
             delegate
             {

--- a/Majson.cs
+++ b/Majson.cs
@@ -102,6 +102,7 @@ public class EditorSetting
     public float playSpeed = 7.5f;
     public string PlayStopKey = "Ctrl+Shift+x";
     public int RenderMode = 0; //0=硬件渲染(默认)，1=软件渲染
+    public int SyntaxCheckLevel = 1; //0=禁用，1=警告(默认)，2=启用
     public string SaveKey = "Ctrl+s";
     public string SendViewerKey = "Ctrl+Shift+z";
     public float touchSpeed = 7.5f;

--- a/Mirror.cs
+++ b/Mirror.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text;
+using System.Text.RegularExpressions;
 
 namespace MajdataEdit;
 
@@ -14,25 +15,28 @@ internal static class Mirror
         CcwRotation45
     }
 
-    private static readonly Dictionary<char, char> MirrorLeftToRight = new()
+    private static readonly Dictionary<char, char> MIRROR_LEFT_RIGHT_MAP = new()
     {
-        { '8', '1' },
         { '1', '8' },
         { '2', '7' },
-        { '7', '2' },
         { '3', '6' },
-        { '6', '3' },
         { '4', '5' },
         { '5', '4' },
+        { '6', '3' },
+        { '7', '2' },
+        { '8', '1' },
         { 'q', 'p' },
         { 'p', 'q' },
         { '<', '>' },
         { '>', '<' },
         { 'z', 's' },
         { 's', 'z' }
-    }; //Note左右
+    };
 
-    private static readonly Dictionary<char, char> MirrorTouchLeftToRight = new()
+    // 当遇到这些字符时 使用特殊的映射表
+    private static readonly HashSet<char> MIRROR_SPECIAL_PREFIX = new() { 'D', 'E' };
+
+    private static readonly Dictionary<char, char> MIRROR_LEFT_RIGHT_SPECIAL_MAP = new()
     {
         { '8', '2' },
         { '2', '8' },
@@ -42,9 +46,9 @@ internal static class Mirror
         { '6', '4' },
         { '1', '1' },
         { '5', '5' }
-    }; //Touch左右
+    };
 
-    private static readonly Dictionary<char, char> MirrorUpsideDown = new()
+    private static readonly Dictionary<char, char> MIRROR_UPSIDE_DOWN_MAP = new()
     {
         { '4', '1' },
         { '5', '8' },
@@ -58,9 +62,9 @@ internal static class Mirror
         { 'p', 'q' },
         { 'z', 's' },
         { 's', 'z' }
-    }; //上下（全反=上下+左右）
+    };
 
-    private static readonly Dictionary<char, char> MirrorTouchUpsideDown = new()
+    private static readonly Dictionary<char, char> MIRROR_UPSIDE_DOWN_SPECIAL_MAP = new()
     {
         { '4', '2' },
         { '2', '4' },
@@ -70,23 +74,9 @@ internal static class Mirror
         { '6', '8' },
         { '3', '3' },
         { '7', '7' }
-    }; //Touch上下
+    };
 
-    private static readonly Dictionary<char, char> Mirror180 = new()
-    {
-        { '5', '1' },
-        { '4', '8' },
-        { '3', '7' },
-        { '6', '2' },
-        { '2', '6' },
-        { '7', '3' },
-        { '1', '5' },
-        { '8', '4' },
-        { '<', '>' },
-        { '>', '<' }
-    }; //180旋转
-
-    private static readonly Dictionary<char, char> Mirror45 = new()
+    private static readonly Dictionary<char, char> ROTATE_CW_45_MAP = new()
     {
         { '8', '1' },
         { '7', '8' },
@@ -98,7 +88,7 @@ internal static class Mirror
         { '1', '2' }
     };
 
-    private static readonly Dictionary<char, char> MirrorCcw45 = new()
+    private static readonly Dictionary<char, char> ROTATE_CCW_45_MAP = new()
     {
         { '1', '8' },
         { '2', '1' },
@@ -110,793 +100,201 @@ internal static class Mirror
         { '8', '7' }
     };
 
-    private static readonly Dictionary<char, char> Mirror45special = new()
+    private static readonly HashSet<char> ROTATE_CW_45_SPECIAL_PREFIX = new() { '2', '6' };
+
+    private static readonly HashSet<char> ROTATE_CCW_45_SPECIAL_PREFIX = new() { '3', '7' };
+
+    private static readonly Dictionary<char, char> ROTATE_45_SPECIAL_MAP = new()
     {
         { '<', '>' },
         { '>', '<' }
-    }; //2、6或3、7键位旋转改变<>符号
+    };
 
-    public static string NoteMirrorHandle(string str, HandleType Type)
+    private static readonly string HS_SEQUENCE = "<HS*";
+
+    public static string NoteMirrorHandle(string str, HandleType type)
     {
-        var handledStr = "";
-        var noteStr = Regex.Replace(str, @"\s", "").Split(new[] { "," }, StringSplitOptions.None);
-        var arrayIndex = 0;
-        foreach (var note in noteStr)
+        // NOTE: 类似 1-5[8:1]{16}, 这样的字符串 可以被SimaiProcess处理 但无法被正确镜像
+        // 我认为这是对的 因为这种语法本身就是错误的 只不过SimaiProcess没有做处理而已 不能因此而妥协 以上
+
+        StringBuilder resultString = new StringBuilder();   // 最终的结果
+        StringBuilder curPart = new StringBuilder();        // 当前的一部分
+        bool isPartIgnored = false;     // 当前部分是否需要被忽略
+        int hsStatus = 0;              // 当前部分是否是HS语法的一部分 0-未检测到 1-检测到< 2-检测到H 3-检测到S 4-检测到*  必须按照01234的顺序走完才算HS 否则不算
+        
+        // 空白字符会被正常加入每一个part 因此应当在子方法中进行忽略处理 这是为了保持空白字符位置不变
+        foreach (char c in str)
         {
-            var isArg = false;
-            var isSpTouch = false;
-            foreach (var a in note)
+            curPart.Append(c);
+
+            // 如果存在以下字符 则本部分一定是被忽略的
+            if (!isPartIgnored && (c == '{' || c == '}' || c == '(' || c == ')'))
             {
-                var index = note.IndexOf(a);
-                if (new[] { '{', '[', '(' }.Contains(a))
+                isPartIgnored = true;
+            }
+
+            if (hsStatus == 0)
+            {
+                if (HS_SEQUENCE[0] == c)
                 {
-                    isArg = true;
-                    handledStr += a;
-                    continue;
+                    // 检查到了疑似HS语法的开头 开始检查接下来的字符
+                    hsStatus = 1;
                 }
-
-                if (a.Equals('<') && index < note.Length - 1 && note[index + 1].Equals('H'))
+            }
+            else if (hsStatus != HS_SEQUENCE.Length)
+            {
+                // 如果hsStatus不是0 说明已经开始检查了 那么接下来就必须严格紧凑地检查到剩余的HS语法字符
+                // 当然 空白字符不算
+                if (!Char.IsWhiteSpace(c))
                 {
-                    isArg = true;
-                    handledStr += a;
-                    continue;
-                }
-
-                if (new[] { '}', ']', ')', '>' }.Contains(a))
-                {
-                    isArg = false;
-                    handledStr += a;
-                    continue;
-                }
-
-                if (isArg)
-                {
-                    handledStr += a;
-                    continue;
-                }
-
-                switch (Type)
-                {
-                    case HandleType.LRMirror:
-                        if (new[] { 'E', 'D' }.Contains(a)) //D区及E区Touch特殊处理
+                    if (HS_SEQUENCE[hsStatus] == c)
+                    {
+                        // 符合 则步进
+                        hsStatus++;
+                        if (hsStatus == HS_SEQUENCE.Length)
                         {
-                            isSpTouch = true;
-                            handledStr += a;
-                            continue;
+                            // 检查到结尾了 则肯定是一个hs结构了
+                            isPartIgnored = true;
                         }
-
-                        if (isSpTouch)
-                        {
-                            handledStr += MirrorTouchLeftToRight[a];
-                            isSpTouch = false;
-                            continue;
-                        }
-
-                        if (MirrorLeftToRight.ContainsKey(a))
-                        {
-                            if (note[Math.Max(0, index - 1)].Equals('C'))
-                                continue;
-                            handledStr += MirrorLeftToRight[a];
-                        }
-                        else
-                        {
-                            handledStr += a;
-                        }
-
-                        break;
-                    case HandleType.UDMirror:
-                        if (new[] { 'E', 'D' }.Contains(a)) //D区及E区Touch特殊处理
-                        {
-                            isSpTouch = true;
-                            handledStr += a;
-                            continue;
-                        }
-
-                        if (isSpTouch)
-                        {
-                            handledStr += MirrorTouchUpsideDown[a];
-                            isSpTouch = false;
-                            continue;
-                        }
-
-                        if (MirrorUpsideDown.ContainsKey(a))
-                        {
-                            if (note[Math.Max(0, index - 1)].Equals('C'))
-                                continue;
-                            handledStr += MirrorUpsideDown[a];
-                        }
-                        else
-                        {
-                            handledStr += a;
-                        }
-
-                        break;
-                    case HandleType.HalfRotation:
-                        if (Mirror180.ContainsKey(a))
-                        {
-                            if (note[Math.Max(0, index - 1)].Equals('C'))
-                                continue;
-                            handledStr += Mirror180[a];
-                        }
-                        else
-                        {
-                            handledStr += a;
-                        }
-
-                        break;
-                    case HandleType.Rotation45:
-                        if (Mirror45.ContainsKey(a))
-                        {
-                            if (note[Math.Max(0, index - 1)].Equals('C'))
-                                continue;
-                            handledStr += Mirror45[a];
-                        }
-                        else if (Mirror45special.ContainsKey(a) &&
-                                 new[] { '2', '6' }.Contains(note[index - 1])) //2、6号键位"<"或">"Slide需要特殊处理
-                        {
-                            handledStr += Mirror45special[a];
-                        }
-                        else
-                        {
-                            handledStr += a;
-                        }
-
-                        break;
-                    case HandleType.CcwRotation45:
-                        if (MirrorCcw45.ContainsKey(a))
-                        {
-                            if (note[Math.Max(0, index - 1)].Equals('C'))
-                                continue;
-                            handledStr += MirrorCcw45[a];
-                        }
-                        else if (Mirror45special.ContainsKey(a) &&
-                                 new[] { '3', '7' }.Contains(note[index - 1])) //3、7号键位"<"或">"Slide需要特殊处理
-                        {
-                            handledStr += Mirror45special[a];
-                        }
-                        else
-                        {
-                            handledStr += a;
-                        }
-
-                        break;
+                    }
+                    else
+                    {
+                        // 不符合 说明这不是一个HS结构 则归零重新开始探索
+                        hsStatus = 0;
+                    }
                 }
             }
 
-            if (arrayIndex++ < noteStr.Length - 1)
-                handledStr += ",";
+            // 以下字符表示本part结束
+            if (c == '}' || c == ')' || c == ',' || c == '/' || c == '`' ||
+                (hsStatus == 4 && c == '>'))
+            {
+                if (isPartIgnored)
+                {
+                    // 需要忽略的段落 直接原样加进去就行了
+                    resultString.Append(curPart.ToString());
+                }
+                else
+                {
+                    // 需要镜像计算的段落 调用子方法进行转换
+                    resultString.Append(NoteMirrorPart(curPart.ToString(), type));
+                }
+
+                isPartIgnored = false;
+                hsStatus = 0;
+                curPart.Clear();
+            }
         }
 
-        return handledStr;
+        // 处理完以后可能还会有剩余的没做转换（可能结尾的逗号没选进去） 也要处理一下
+        if (curPart.Length > 0)
+        {
+            if (isPartIgnored)
+            {
+                // 需要忽略的段落 直接原样加进去就行了
+                resultString.Append(curPart.ToString());
+            }
+            else
+            {
+                // 需要镜像计算的段落 调用子方法进行转换
+                resultString.Append(NoteMirrorPart(curPart.ToString(), type));
+            }
+        }
+
+        return resultString.ToString();
     }
-    //static public string NoteMirrorLeftRight(string str) //左右镜像
-    //{
 
-    //    string handledStr = "";
-    //    Dictionary<char, char> MirrorLeftToRight = new Dictionary<char, char>()
-    //    {
-    //        { '8','1' },
-    //        { '1','8' },
-    //        { '2','7' },
-    //        { '7','2' },
-    //        { '3','6' },
-    //        { '6','3' },
-    //        { '4','5' },
-    //        { '5','4' },
-    //        { 'q','p' },
-    //        { 'p','q' },
-    //        { '<','>' },
-    //        { '>','<' },
-    //        { 'z','s' },
-    //        { 's','z' }
-    //    };//Note左右
-    //    Dictionary<char, char> MirrorTouchLeftToRight = new Dictionary<char, char>()
-    //    {
-    //        { '8','2' },
-    //        { '2','8' },
-    //        { '3','7' },
-    //        { '7','3' },
-    //        { '4','6' },
-    //        { '6','4' },
-    //        { '1','1' },
-    //        { '5','5' }
-    //    };//Touch左右
-    //    string[] noteStr = Regex.Replace(str, @"\s", "").Split(new string[] { "," }, StringSplitOptions.None);
-    //    int arrayIndex = 0;
-    //    foreach (var note in noteStr)
-    //    {
-    //        bool isArg = false;
-    //        bool isSpTouch = false;
-    //        foreach (var a in note)
-    //        {
-    //            var index = note.IndexOf(a);
-    //            if ((new char[] { '{', '[', '(' }).Contains(a))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (a.Equals('<') && index < note.Length - 1 && note[index + 1].Equals('H'))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if ((new char[] { '}', ']', ')', '>' }).Contains(a))
-    //            {
-    //                isArg = false;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (isArg)
-    //            {
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else
-    //            {
-    //                if ((new char[] { 'E', 'D' }).Contains(a)) //D区及E区Touch特殊处理
-    //                {
-    //                    isSpTouch = true;
-    //                    handledStr += a;
-    //                    continue;
-    //                }
-    //                else if (isSpTouch)
-    //                {
-    //                    handledStr += MirrorTouchLeftToRight[a];
-    //                    isSpTouch = false;
-    //                    continue;
-    //                }
-    //                if (MirrorLeftToRight.ContainsKey(a))
-    //                    handledStr += MirrorLeftToRight[a];
-    //                else
-    //                    handledStr += a;
-    //            }
-    //        }
-    //        if (arrayIndex++ < noteStr.Length - 1)
-    //            handledStr += ",";
-    //    }
-    //    return handledStr;
+    private static string NoteMirrorPart(string str, HandleType type)
+    {
+        switch (type)
+        {
+            case HandleType.LRMirror:    
+                str = NormalMirrorPart(str, MIRROR_LEFT_RIGHT_MAP, MIRROR_LEFT_RIGHT_SPECIAL_MAP, MIRROR_SPECIAL_PREFIX);
+                break;    
+            case HandleType.UDMirror:
+                str = NormalMirrorPart(str, MIRROR_UPSIDE_DOWN_MAP, MIRROR_UPSIDE_DOWN_SPECIAL_MAP, MIRROR_SPECIAL_PREFIX);
+                break;
+            case HandleType.HalfRotation:
+                // 180 = 左右+上下
+                str = NormalMirrorPart(str, MIRROR_LEFT_RIGHT_MAP, MIRROR_LEFT_RIGHT_SPECIAL_MAP, MIRROR_SPECIAL_PREFIX);
+                str = NormalMirrorPart(str, MIRROR_UPSIDE_DOWN_MAP, MIRROR_UPSIDE_DOWN_SPECIAL_MAP, MIRROR_SPECIAL_PREFIX);
+                break;
+            case HandleType.Rotation45:
+                str = NormalMirrorPart(str, ROTATE_CW_45_MAP, ROTATE_45_SPECIAL_MAP, ROTATE_CW_45_SPECIAL_PREFIX);
+                break;
+            case HandleType.CcwRotation45:
+                str = NormalMirrorPart(str, ROTATE_CCW_45_MAP, ROTATE_45_SPECIAL_MAP, ROTATE_CCW_45_SPECIAL_PREFIX);
+                break;
+        }
 
+        return str;
+    }
 
-    //    char[] a = str.ToCharArray();
-    //    for (int i = 0; i < a.Length; i++)
-    //    {
-    //        string s1 = a[i].ToString();
-    //        if (a[i] == '{' || a[i] == '[' || a[i] == '(')
-    //        {
-    //            s += s1;
+    private static string NormalMirrorPart(string str, Dictionary<char, char> normalMap, Dictionary<char, char> specialMap, HashSet<char> specialPrefix)
+    {
+        StringBuilder result = new StringBuilder();
+        bool isSpecialPrefix = false;
+        bool isInBracket = false;
 
-    //            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //            {
-    //                i += 1;
-    //                s += a[i];
-    //            }
-    //        }
-    //        else
-    //        {
-    //            if (MirrorLeftToRight.ContainsKey(s1))
-    //            {
-    //                s += MirrorLeftToRight[s1];
-    //            }
-    //            else if (a[i] == 'e' || a[i] == 'd' || a[i] == 'E' || a[i] == 'D')
-    //            {
-    //                s += a[i];
-    //                i += 1;
-    //                string st = a[i].ToString();
-    //                if (MirrorTouchLeftToRight.ContainsKey(st))
-    //                {
-    //                    s += MirrorTouchLeftToRight[st];
-    //                }
-    //                else
-    //                {
-    //                    s += a[i];
-    //                }
-    //            }
-    //            else
-    //            {
-    //                s += s1;
-    //            }
-    //        }
+        foreach (char c in str)
+        {
+            // 空白字符忽略
+            if (Char.IsWhiteSpace(c))
+            {
+                result.Append(c);
+                continue;
+            }
 
+            // 以下是处理字符的部分
+            if (isInBracket || c == '[')
+            {
+                // 进入方括号时忽略 因为这里是时长之类的设置
+                // 注意当前字符为'['的时候也进入此分支 因为此时isInBrancket还是false 需要等到下面那个if块才会变
+                result.Append(c);
+            }
+            else if (isSpecialPrefix)
+            {
+                // 如果前面读到一个D或者E 则使用特殊的映射
+                isSpecialPrefix = false;
+                if (specialMap.ContainsKey(c))
+                {
+                    result.Append(specialMap[c]);
+                }
+                else
+                {
+                    result.Append(c);
+                }
+            }
+            else
+            {
+                // 其他情况 则使用默认映射
+                if (normalMap.ContainsKey(c))
+                {
+                    result.Append(normalMap[c]);
+                } 
+                else
+                {
+                    result.Append(c);
+                }
+            }
 
-    //    }
-    //}
-    //static public string NoteMirrorUpDown(string str)//上下翻转
-    //{
+            // 以下是记录状态的部分
+            // 记录是否进入了方括号内（即时间）
+            if (c == '[')
+            {
+                isInBracket = true;
+            }
+            else if (c == ']')
+            {
+                isInBracket = false;
+            }
+            // 记录是否是一个特殊前缀 若是 则下面的字符需要使用特别的映射
+            if (specialPrefix.Contains(c))
+            {
+                isSpecialPrefix = true;
+            }
+        }
 
-    //    string handledStr = "";
-    //    Dictionary<char, char> MirrorUpsideDown = new Dictionary<char, char>()
-    //    {
-    //        { '4','1' },
-    //        { '5','8' },
-    //        { '6','7' },
-    //        { '3','2' },
-    //        { '7','6' },
-    //        { '2','3' },
-    //        { '8','5' },
-    //        { '1','4' },
-    //        { 'q','p' },
-    //        { 'p','q' },
-    //        { 'z','s' },
-    //        { 's','z' }
-    //    };//上下（全反=上下+左右）
-    //    Dictionary<char, char> MirrorTouchUpsideDown = new Dictionary<char, char>()
-    //    {
-    //        { '4','2' },
-    //        { '2','4' },
-    //        { '1','5' },
-    //        { '5','1' },
-    //        { '8','6' },
-    //        { '6','8' },
-    //        { '3','3' },
-    //        { '7','7' }
-    //    };//Touch左右
-    //    string[] noteStr = Regex.Replace(str, @"\s", "").Split(new string[] { "," }, StringSplitOptions.None);
-    //    int arrayIndex = 0;
-    //    foreach (var note in noteStr)
-    //    {
-    //        bool isArg = false;
-    //        bool isSpTouch = false;
-    //        foreach (var a in note)
-    //        {
-    //            var index = note.IndexOf(a);
-    //            if ((new char[] { '{', '[', '(' }).Contains(a))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (a.Equals('<') && index < note.Length - 1 && note[index + 1].Equals('H'))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if ((new char[] { '}', ']', ')', '>' }).Contains(a))
-    //            {
-    //                isArg = false;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (isArg)
-    //            {
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else
-    //            {
-    //                if ((new char[] { 'E', 'D' }).Contains(a)) //D区及E区Touch特殊处理
-    //                {
-    //                    isSpTouch = true;
-    //                    handledStr += a;
-    //                    continue;
-    //                }
-    //                else if (isSpTouch)
-    //                {
-    //                    handledStr += MirrorTouchUpsideDown[a];
-    //                    isSpTouch = false;
-    //                    continue;
-    //                }
-    //                if (MirrorUpsideDown.ContainsKey(a))
-    //                    handledStr += MirrorUpsideDown[a];
-    //                else
-    //                    handledStr += a;
-    //            }
-    //        }
-    //        if (arrayIndex++ < noteStr.Length - 1)
-    //            handledStr += ",";
-    //    }
-    //    return handledStr;
-    //    char[] a = str.ToCharArray();
-    //    for (int i = 0; i < a.Length; i++)
-    //    {
-    //        string s1 = a[i].ToString();
-    //        if (a[i] == '{' || a[i] == '[' || a[i] == '(')//跳过括号内内容
-    //        {
-    //            s += s1;
-
-    //            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //            {
-    //                i += 1;
-    //                s += a[i];
-
-
-    //            }
-    //        }
-    //        else
-    //        {
-    //            if (MirrorUpsideDown.ContainsKey(s1))
-    //            {
-    //                s += MirrorUpsideDown[s1];
-    //            }
-    //            else if (a[i] == 'e' || a[i] == 'd' || a[i] == 'E' || a[i] == 'D')
-    //            {
-    //                s += a[i];
-    //                i += 1;
-    //                string st = a[i].ToString();
-    //                if (MirrorTouchUpsideDown.ContainsKey(st))
-    //                {
-    //                    s += MirrorTouchUpsideDown[st];
-    //                }
-    //            }
-    //            else
-    //            {
-    //                s += s1;
-    //            }
-    //        }
-
-
-    //    }
-    //    Console.WriteLine(s);
-    //    Console.ReadKey();
-    //    return s;
-    //}
-    //static public string NoteMirror180(string str)//翻转180°
-    //{
-
-    //    string handledStr = "";
-    //    Dictionary<char, char> Mirror180 = new Dictionary<char, char>()
-    //    {
-    //        {'5','1'},
-    //        {'4','8'},
-    //        {'3','7'},
-    //        {'6','2'},
-    //        {'2','6'},
-    //        {'7','3'},
-    //        {'1','5'},
-    //        {'8','4'},
-    //        {'<','>'},
-    //        {'>','<'}
-    //    };
-    //    string[] noteStr = Regex.Replace(str, @"\s", "").Split(new string[] { "," }, StringSplitOptions.None);
-    //    int arrayIndex = 0;
-    //    foreach (var note in noteStr)
-    //    {
-    //        bool isArg = false;
-    //        foreach (var a in note)
-    //        {
-    //            var index = note.IndexOf(a);
-    //            if ((new char[] { '{', '[', '(' }).Contains(a))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (a.Equals('<') && index < note.Length - 1 && note[index + 1].Equals('H'))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if ((new char[] { '}', ']', ')', '>' }).Contains(a))
-    //            {
-    //                isArg = false;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (isArg)
-    //            {
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else
-    //            {
-    //                if (Mirror180.ContainsKey(a))
-    //                    handledStr += Mirror180[a];
-    //                else
-    //                    handledStr += a;
-    //            }
-    //        }
-    //        if (arrayIndex++ < noteStr.Length - 1)
-    //            handledStr += ",";
-    //    }
-
-    //    return handledStr;
-    //    char[] a = str.ToCharArray();
-    //    for (int i = 0; i < a.Length; i++)
-    //    {
-    //        string s1 = a[i].ToString();
-    //        if (a[i] == '{' || a[i] == '[' || a[i] == '(')
-    //        {
-    //            s += s1;
-    //            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //            {
-    //                i += 1;
-    //                s += a[i];
-
-
-    //            }
-    //        }
-    //        else
-    //        {
-    //            if (Mirror180.ContainsKey(s1))
-    //            {
-    //                s += Mirror180[s1];
-    //            }
-
-    //            else
-    //            {
-    //                s += s1;
-    //            }
-    //        }
-    //    }
-    //}
-    //static public string NoteMirrorSpin45(string str)//顺时针旋转45
-    //{
-    //    string handledStr = "";
-    //    Dictionary<char, char> Mirror45 = new Dictionary<char, char>()
-    //    {
-    //        { '8','1' },
-    //        { '7','8' },
-    //        { '6','7' },
-    //        { '5','6' },
-    //        { '4','5' },
-    //        { '3','4' },
-    //        { '2','3' },
-    //        { '1','2' }
-    //    };
-    //    Dictionary<char, char> Mirror45special = new Dictionary<char, char>()
-    //    {
-    //        { '<','>' },
-    //        { '>','<' }
-    //    };//2或6键位旋转改变<>符号
-    //    string[] noteStr = Regex.Replace(str, @"\s", "").Split(new string[] { "," }, StringSplitOptions.None);
-    //    int arrayIndex = 0;
-    //    foreach (var note in noteStr)
-    //    {
-    //        bool isArg = false;
-    //        foreach (var a in note)
-    //        {
-    //            var index = note.IndexOf(a);
-    //            if ((new char[] { '{', '[', '(' }).Contains(a))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (a.Equals('<') && index < note.Length - 1 && note[index + 1].Equals('H'))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if ((new char[] { '}', ']', ')', '>' }).Contains(a))
-    //            {
-    //                isArg = false;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (isArg)
-    //            {
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else
-    //            {
-
-    //                if (Mirror45.ContainsKey(a))
-    //                    handledStr += Mirror45[a];
-    //                else if (Mirror45special.ContainsKey(a) && (new char[] { '2', '6' }).Contains(note[index - 1]))//2、6号键位"<"或">"Slide需要特殊处理
-    //                    handledStr += Mirror45special[a];
-    //                else
-    //                    handledStr += a;
-    //            }
-    //        }
-    //        if (arrayIndex++ < noteStr.Length - 1)
-    //            handledStr += ",";
-    //    }
-    //    return handledStr;
-
-    //    char[] a = str.ToCharArray();
-    //    for (int i = 0; i < a.Length; i++)
-    //    {
-    //        string s1 = a[i].ToString();
-    //        if (a[i] == '{' || a[i] == '[' || a[i] == '(')
-    //        {
-    //            s += s1;
-
-    //            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //            {
-    //                i += 1;
-    //                s += a[i];
-    //            }
-    //        }
-    //        else
-    //        {
-    //            if (Mirror45.ContainsKey(s1))
-    //            {
-    //                if (i + 2 < a.Length && (a[i] == '2' || a[i] == '6') && a[i + 1] != '[')
-    //                {
-    //                    s += Mirror45[s1];
-    //                    while (i + 1 < a.Length && a[i] != ',')
-    //                    {
-    //                        i += 1;
-    //                        string st = a[i].ToString();
-    //                        if (st == "/")
-    //                        {
-    //                            s += "/";
-    //                            break;
-    //                        }
-    //                        else if (st == "[")
-    //                        {
-    //                            s += st;
-
-    //                            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //                            {
-    //                                i += 1;
-    //                                s += a[i];
-
-
-    //                            }
-    //                        }
-    //                        else if (Mirror45special.ContainsKey(st))
-    //                        {
-    //                            s += Mirror45special[st];
-
-    //                        }
-    //                        else if (Mirror45.ContainsKey(st))
-    //                        {
-    //                            s += Mirror45[st];
-    //                        }
-    //                        else
-    //                        {
-    //                            s += st;
-
-    //                        }
-    //                    }
-    //                }
-    //                else
-    //                {
-    //                    s += Mirror45[s1];
-    //                }
-    //            }
-
-    //            else
-    //            {
-    //                s += s1;
-    //            }
-    //        }
-    //    }
-    //    return s;
-    //}
-    //static public string NoteMirrorSpinCcw45(string str)//逆时针旋转45
-    //{
-    //    anti - clockwise
-    //    string handledStr = "";
-    //    Dictionary<char, char> Mirror45 = new Dictionary<char, char>()
-    //    {
-    //        { '1','8' },
-    //        { '2','1' },
-    //        { '3','2' },
-    //        { '4','3' },
-    //        { '5','4' },
-    //        { '6','5' },
-    //        { '7','6' },
-    //        { '8','7' }
-    //    };
-    //    Dictionary<char, char> Mirror45special = new Dictionary<char, char>()
-    //    {
-    //        { '<','>'},
-    //        { '>','<'}
-    //    };//3或7键位旋转改变<>符号
-    //    string[] noteStr = Regex.Replace(str, @"\s", "").Split(new string[] { "," }, StringSplitOptions.None);
-    //    int arrayIndex = 0;
-    //    foreach (var note in noteStr)
-    //    {
-    //        bool isArg = false;
-    //        foreach (var a in note)
-    //        {
-    //            var index = note.IndexOf(a);
-    //            if ((new char[] { '{', '[', '(' }).Contains(a))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (a.Equals('<') && index < note.Length - 1 && note[index + 1].Equals('H'))
-    //            {
-    //                isArg = true;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if ((new char[] { '}', ']', ')', '>' }).Contains(a))
-    //            {
-    //                isArg = false;
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else if (isArg)
-    //            {
-    //                handledStr += a;
-    //                continue;
-    //            }
-    //            else
-    //            {
-
-    //                if (Mirror45.ContainsKey(a))
-    //                    handledStr += Mirror45[a];
-    //                else if (Mirror45special.ContainsKey(a) && (new char[] { '3', '7' }).Contains(note[index - 1]))//3、7号键位"<"或">"Slide需要特殊处理
-    //                    handledStr += Mirror45special[a];
-    //                else
-    //                    handledStr += a;
-    //            }
-    //        }
-    //        if (arrayIndex++ < noteStr.Length - 1)
-    //            handledStr += ",";
-    //    }
-    //    return handledStr;
-
-    //    char[] a = str.ToCharArray();
-    //    for (int i = 0; i < a.Length; i++)
-    //    {
-    //        string s1 = a[i].ToString();
-    //        if (a[i] == '{' || a[i] == '[' || a[i] == '(')
-    //        {
-    //            s += s1;
-
-    //            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //            {
-    //                i += 1;
-    //                s += a[i];
-    //            }
-    //        }
-    //        else
-    //        {
-    //            if (Mirror45.ContainsKey(s1))
-    //            {
-    //                if (i + 2 < a.Length && (a[i] == '3' || a[i] == '7') && a[i + 1] != '[')
-    //                {
-    //                    s += Mirror45[s1];
-    //                    while (i + 1 < a.Length && a[i] != ',')
-    //                    {
-    //                        i += 1;
-    //                        string st = a[i].ToString();
-    //                        if (st == "/")
-    //                        {
-    //                            s += "/";
-    //                            break;
-    //                        }
-    //                        else if (st == "[")
-    //                        {
-    //                            s += st;
-
-    //                            while (i + 1 < a.Length && a[i] != '}' && a[i] != ']' && a[i] != ')')
-    //                            {
-    //                                i += 1;
-    //                                s += a[i];
-
-
-    //                            }
-    //                        }
-    //                        else if (Mirror45special.ContainsKey(st))
-    //                        {
-    //                            s += Mirror45special[st];
-
-    //                        }
-    //                        else if (Mirror45.ContainsKey(st))
-    //                        {
-    //                            s += Mirror45[st];
-    //                        }
-    //                        else
-    //                        {
-    //                            s += st;
-
-    //                        }
-    //                    }
-    //                }
-    //                else
-    //                {
-    //                    s += Mirror45[s1];
-    //                }
-    //            }
-
-    //            else
-    //            {
-    //                s += s1;
-    //            }
-    //        }
-    //    }
-    //    return s;
-    //}
+        return result.ToString();
+    }
 }

--- a/SoundEffect.cs
+++ b/SoundEffect.cs
@@ -735,7 +735,7 @@ public partial class MainWindow
             else
             {
                 // 不够播完 等待后停止
-                var stopPlayingTimer = new Timer((int)(extraTime4AllPerfect * 1000))
+                var stopPlayingTimer = new Timer(double.IsNormal(extraTime4AllPerfect)? (int)(extraTime4AllPerfect * 1000) : int.MaxValue)
                 {
                     AutoReset = false
                 };

--- a/SubWindow/EditorSettingPanel.xaml
+++ b/SubWindow/EditorSettingPanel.xaml
@@ -11,13 +11,13 @@
         Background="{DynamicResource WindowBackground}"
         Title="Editor Setting" SizeToContent="WidthAndHeight" ResizeMode="NoResize" WindowStartupLocation="CenterOwner"
         Topmost="True"
-        Loaded="Window_Loaded" Closing="Window_Closing" Height="323.667">
+        Loaded="Window_Loaded" Closing="Window_Closing" Height="361">
     <Window.Resources>
 
     </Window.Resources>
 
 
-    <Grid Margin="8,5">
+    <Grid Margin="0,5,0,57">
         <Grid.Resources>
             <Style TargetType="{x:Type Label}">
                 <Setter Property="VerticalAlignment" Value="Center" />
@@ -123,13 +123,13 @@
             <ComboBoxItem Content="{lex:Loc Key=ComboDisplayCScoreDownDedeluxe}" />
         </ComboBox>
 
-        <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
+        <StackPanel Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="5,25,-5,8">
             <CheckBox x:Name="AutoUpdate" VerticalAlignment="Center" />
             <Label
         Content="{lex:Loc Key=AutoCheckUpdate}" />
         </StackPanel>
 
-        <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal">
+        <StackPanel Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="5,39,-5,-17">
             <CheckBox x:Name="SmoothSlideAnime" VerticalAlignment="Center" />
             <Label
         Content="{lex:Loc Key=EnableSmoothSlideAnime}" />
@@ -147,7 +147,7 @@
 
 
         <StackPanel Orientation="Horizontal"
-                    Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center">
+                    Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Left" Margin="6,55,0,-55">
             <Button x:Name="Save_Button" Content="{lex:Loc Key=Save}"
                     Width="70" Height="28" Margin="0,5,10,5"
                     Foreground="{DynamicResource ButtonForeground}"
@@ -159,6 +159,14 @@
                     Background="{DynamicResource ButtonsBackground}"
                     Click="Cancel_Button_Click" />
         </StackPanel>
+        <Label Grid.Row="9" Grid.Column="0"
+            Content="{lex:Loc Key=SyntaxDisplay}" VerticalAlignment="Top" />
+        <ComboBox x:Name="SyntaxCheckLevel"
+            Grid.Row="9" VerticalAlignment="Top" Grid.ColumnSpan="2" Margin="114,1,0,0" SelectedIndex="2">
+            <ComboBoxItem Content="{lex:Loc Key=SyntaxCheckLevel1}" />
+            <ComboBoxItem Content="{lex:Loc Key=SyntaxCheckLevel2}" />
+            <ComboBoxItem Content="{lex:Loc Key=SyntaxCheckLevel3}" />
+        </ComboBox>
     </Grid>
 
 </Window>

--- a/SubWindow/EditorSettingPanel.xaml
+++ b/SubWindow/EditorSettingPanel.xaml
@@ -162,7 +162,7 @@
         <Label Grid.Row="9" Grid.Column="0"
             Content="{lex:Loc Key=SyntaxDisplay}" VerticalAlignment="Top" />
         <ComboBox x:Name="SyntaxCheckLevel"
-            Grid.Row="9" VerticalAlignment="Top" Grid.ColumnSpan="2" Margin="114,1,0,0" SelectedIndex="2">
+            Grid.Row="9" VerticalAlignment="Top" Grid.ColumnSpan="2" Margin="114,1,0,0" SelectedIndex="1">
             <ComboBoxItem Content="{lex:Loc Key=SyntaxCheckLevel1}" />
             <ComboBoxItem Content="{lex:Loc Key=SyntaxCheckLevel2}" />
             <ComboBoxItem Content="{lex:Loc Key=SyntaxCheckLevel3}" />

--- a/SubWindow/EditorSettingPanel.xaml.cs
+++ b/SubWindow/EditorSettingPanel.xaml.cs
@@ -60,6 +60,7 @@ public partial class EditorSettingPanel : Window
         ChartRefreshDelay.Text = window.editorSetting.ChartRefreshDelay.ToString();
         AutoUpdate.IsChecked = window.editorSetting.AutoCheckUpdate;
         SmoothSlideAnime.IsChecked = window.editorSetting.SmoothSlideAnime;
+        SyntaxCheckLevel.SelectedIndex = window.editorSetting.SyntaxCheckLevel;
     }
 
     private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -106,6 +107,7 @@ public partial class EditorSettingPanel : Window
         window.editorSetting!.ChartRefreshDelay = int.Parse(ChartRefreshDelay.Text);
         window.editorSetting!.AutoCheckUpdate = (bool) AutoUpdate.IsChecked!;
         window.editorSetting!.SmoothSlideAnime = (bool) SmoothSlideAnime.IsChecked!;
+        window.editorSetting!.SyntaxCheckLevel = SyntaxCheckLevel.SelectedIndex;
         // window.editorSetting.isComboEnabled = (bool) ComboDisplay.IsChecked!;
         window.editorSetting!.comboStatusType = (EditorComboIndicator)Enum.GetValues(
             window.editorSetting!.comboStatusType.GetType()
@@ -119,6 +121,7 @@ public partial class EditorSettingPanel : Window
 
 
         saveFlag = true;
+        window.SyntaxCheck();
         Close();
     }
 

--- a/SubWindow/MuriCheck.xaml.cs
+++ b/SubWindow/MuriCheck.xaml.cs
@@ -482,6 +482,7 @@ public partial class MuriCheck : Window
         else
         {
             multNoteError = -114514; // This is a MAGIC NUMBER, Do not touch ;)
+                                     // This is really a MAGIC NUMBER, Do not touch Xp
         }
 
         var slideError = slideDetect(slideCheckAccuracy);

--- a/SyntaxModule/SyntaxCheck.cs
+++ b/SyntaxModule/SyntaxCheck.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MajdataEdit.SyntaxModule
+{
+    internal static class SyntaxCheck
+    {
+        static List<SimaiTimingPoint> noteList;
+        //static 
+        static void Scan(string noteStr)
+        {
+            int line = 0;
+            int column = 0;
+        }
+        static void Scan()
+        {
+            noteList = SimaiProcess.notelist;
+
+
+        }
+
+        /// <summary>
+        /// 判断是否为Tap
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        static bool IsTap(string s)
+        {
+            if (s.Length == 1)
+                return int.TryParse(s, out int i) && KeyIndexCheck(i);
+            else if(s.Length == 2)
+            {
+                if (s[1] is 'b' or 'x')
+                    return int.TryParse(s[0..0], out int i) && KeyIndexCheck(i);
+                else
+                    return int.TryParse(s, out int i) && (KeyIndexCheck(i % 10) && KeyIndexCheck(i / 10));
+            }
+
+            return false;
+        }
+        /// <summary>
+        /// 判断是否为Hold，不检查Hold参数
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        static bool IsHold(string s)
+        {
+            if (s.Length >= 2)
+            {
+                var isValidity = int.TryParse(s[0..0], out int i) ? KeyIndexCheck(i) : false ;
+
+                if (s[1] == 'h')
+                    return isValidity;
+                else if(s[2] is 'x' or 'b' && s[1] is 'h')
+                    return isValidity;
+                else if (s[0..1] == "Ch")
+                    return true;
+            }           
+
+            return false;
+        }
+        /// <summary>
+        /// 判断是否为Slide，不检查Slide参数
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        static bool IsSlide(string s)
+        {
+            if(s.Length >= 3)
+            {
+                var isBreakStar = s[1] is 'b';
+                var isHanabiStar = s[1] is 'x';
+                string cStr;
+
+                if (isBreakStar || isHanabiStar)
+                    cStr = int.TryParse(s[3..3], out int i) ? s[2..2] : s[2..3];
+                else
+                    cStr = int.TryParse(s[2..2], out int i) ? s[1..1] : s[1..2];
+
+                switch (cStr)
+                {
+                    case "qq":
+                    case "pp":
+                    case "q":
+                    case "p":
+                    case "w":
+                    case "z":
+                    case "s":
+                    case "V":
+                    case "v":
+                    case "<":
+                    case ">":
+                    case "^":
+                    case "-":
+                        return true;
+                }
+            }
+            return false;
+        }
+        /// <summary>
+        /// 判断是否为Touch
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        static bool IsTouch(string s)
+        {
+            try
+            {
+                if (s.Length == 2)
+                {
+                    var isValidity = int.TryParse(s[1..1], out int i) ? KeyIndexCheck(i) : false;
+                    switch (s[0])
+                    {
+                        case 'A':
+                        case 'B':
+                        case 'C':
+                        case 'D':
+                        case 'E':
+                            return isValidity;
+                    }
+                }
+
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        /// <summary>
+        /// 用于判断键位是否合法
+        /// </summary>
+        /// <param name="k"></param>
+        /// <returns></returns>
+        static bool KeyIndexCheck(int k) => k >= 1 && k <= 8;
+
+    }
+}

--- a/SyntaxModule/SyntaxCheck.cs
+++ b/SyntaxModule/SyntaxCheck.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Windows.Navigation;
+
 namespace MajdataEdit.SyntaxModule
 {
     enum InfomationLevel
@@ -62,7 +64,7 @@ namespace MajdataEdit.SyntaxModule
                 int column = 1;                
                 var simaiChart = str.Split(",");
 
-                if (simaiChart.Last() == "E")//移除结尾E
+                if (simaiChart.Last().Replace("\n","") == "E")//移除结尾E
                     simaiChart = simaiChart.SkipLast(1).ToArray();
                 else
                     addInfo("", -1, -1, "SyntaxWarning", InfomationLevel.Warning);
@@ -869,22 +871,34 @@ namespace MajdataEdit.SyntaxModule
                 return false;
             else if (header is ("Ch" or "C1h" or "Chf" or "C1hf"))//TouchHold特例
                 return true;
-            else if (header[1] != 'h')//第2位不是"h"直接返回
-                return false;
+            //Hold严格判定：第二位必须是'h'，'b'，'x'不限制位置
+            //妥协一下，改为松判定
+            //else if (header[1] != 'h')//第2位不是"h"直接返回
+            //    return false;
 
-            if (header.Length == 2)// e.g. 2h
-                return true;
-            else if (header.Length == 3)// e.g. 2hb,2hx
-                return s[2] is 'b' or 'x';
-            else if (header.Length == 4)// e.g. 2hbx,2hxb
+            //Hold松判定：'h','b','x'不限定位置
+            return header.Length switch
             {
-                var isBreak = s[2] is 'b' || s[3] is 'b';
-                var isHanabi = s[2] is 'x' || s[3] is 'x';
+                2 => header[1] is 'h',
+                3 => header.Contains('h') && (header.Contains('b') || header.Contains('x')),
+                4 => header.Contains('h') && header.Contains('b') && header.Contains('x'),
+                _ => false
+            };
 
-                return isBreak && isHanabi;
-            }
+            //Hold严格判定：第二位必须是'h'，'b'，'x'不限制位置
+            //if (header.Length == 2)// e.g. 2h
+            //    return true;
+            //else if (header.Length == 3)// e.g. 2hb,2hx
+            //    return s[2] is 'b' or 'x';
+            //else if (header.Length == 4)// e.g. 2hbx,2hxb
+            //{
+            //    var isBreak = s[2] is 'b' || s[3] is 'b';
+            //    var isHanabi = s[2] is 'x' || s[3] is 'x';
 
-            return false;
+            //    return isBreak && isHanabi;
+            //}
+
+            //return false;
         }
         /// <summary>
         /// 判断是否为Slide，不检查Slide参数，只检查头部


### PR DESCRIPTION
### 改动
- Simai检查器
- 编辑器设置窗口添加对"语法检查"的设置：”禁用“、"警告"、"启用"
- 当"语法检查"设置为"启用"且检查器认为存在语法错误时，将拒绝播放谱面
- 编辑器左侧栏增加了两个Label用于显示错误数
- 错误列表UI使用无理检测结果UI
- 双击错误数Label会弹出错误列表
### 支持语法
- Tap
   - 普通Tap：`1,2,3,`
   - Break：`1b,2b,3b,`
   - Ex：`1x,2x,3x,`
   - ExBreak：`1bx,2xb,3bx,`
   - Star Tap：`1$$,2$$b,3$$bx/3$$xb,`
- Hold
   - 普通Hold：`1h,2h[1:1],3h[2:1],`
   - Break Hold：`1hb,,2hb[8:1],3hb[16:1],`
   - Ex Hold：`1hx,2hx[8:1],`
   - ExBreak Hold：`1hbx,2hxb,3hbx[8:1],`
   - Touch Hold：`C1h[8:1]`，`Ch[8:1]`，`C1hf[8:1]`，`Chf[8:1]`
   - 特殊参数
      - `[#Seconds]`
      - `[Bpm # Ratio]`
- Slide
   - 所有Slide类型：`-,^,>,<,s,z,q,p,v,V,qq,pp,w,`
   - Break Slide：`1-3[8:1]b`
   - 连结Slide：`1-3-5-7[8:1]`
   - 连结Slide 特殊写法：`1-3[8:1]-5[8:1]-7[8:1]`
   - 特殊参数
      - `[Bpm # Ratio]`
      - `[Bpm # Seconds]`
      - `[Seconds ## Ratio]`
      - `[Seconds ## Seconds]`
      - `[Seconds ## Bpm # Ratio]`
- Touch
   - 支持`A,B,C,D,E`区的Touch
   -  带`f`修饰的Touch
- 多押与伪多押
### 检查范围
- Note键位是否合法（1-8）
- Note修饰符
- 多押或伪多押
- Hold第二，三四位（如果存在）的顺序不检查，但必须是`b`，`x`，`h`
- Hold参数合法性
- Slide种类
- "`V`"类Slide会额外检查拐点与起始点
- Slide路径的合法性，`1-2`或`1w2345`这种将不会通过检查
- Break Slide末尾是否为`b`
- Slide参数合法性
- Touch传感区种类及区号，检查第二或第三位是否为`f`
- HS变速语句检查
- Bpm声明与拍号检查：Bpm可以为浮点数，拍号必须为整数；Bpm与拍号需在Note语句前方
- 谱面是否以"`E`"结尾（不影响谱面播放）
### 测试
对20+谱面（主要以标准谱为主）进行测试，暂未发现问题
### 备注
此pr相当于给MajdataEdit外挂了一个simai检查器，检查器以异步的方式运行
在某种程度上可以解决 https://github.com/LingFeng-bbben/MajdataEdit/issues/47 和 https://github.com/LingFeng-bbben/MajdataView/issues/73 中的问题（？