### PR TITLE
bugfix: Use BASSFlag.BASS_STREAM_PRESCAN when creating stream from file

### DIFF
--- a/MainWindowCore.cs
+++ b/MainWindowCore.cs
@@ -271,7 +271,7 @@ public partial class MainWindow : Window
         }
 
         //soundSetting.Close();
-        var decodeStream = Bass.BASS_StreamCreateFile(audioPath, 0L, 0L, BASSFlag.BASS_STREAM_DECODE);
+        var decodeStream = Bass.BASS_StreamCreateFile(audioPath, 0L, 0L, BASSFlag.BASS_STREAM_DECODE | BASSFlag.BASS_STREAM_PRESCAN);
         bgmStream = BassFx.BASS_FX_TempoCreate(decodeStream, BASSFlag.BASS_FX_FREESOURCE);
         //Bass.BASS_StreamCreateFile(audioPath, 0L, 0L, BASSFlag.BASS_SAMPLE_FLOAT);
 


### PR DESCRIPTION
This allows pin-point accurate seeking for VBR mp3 files.

https://wiki.hydrogenaud.io/index.php?title=Variable_Bitrate