### PR TITLE
Fix: when param values in maidata.txt contains "=", they won't be imported completely.

### DIFF
--- a/SimaiProcess.cs
+++ b/SimaiProcess.cs
@@ -120,7 +120,7 @@ internal static class SimaiProcess
 
     private static string GetValue(string varline)
     {
-        return varline.Split('=')[1];
+        return varline.Substring(varline.IndexOf("=") + 1);
     }
 
     /// <summary>


### PR DESCRIPTION
For example, when maidata.txt contains fumen info like this:
```
&title=BPM=RT
&artist=t+pazolite
&first=0
&des=<color=#1f1e33>C6H6Cl6</color>
```
The program will import "Title" as `BPM` instead of as `BPM=RT` and "Designer" as `<color` instead of `<color=#1f1e33>C6H6Cl6</color>`.